### PR TITLE
Platform modularization: design, roadmap, and M6 plan

### DIFF
--- a/docs/DESIGN-platform.md
+++ b/docs/DESIGN-platform.md
@@ -1,0 +1,159 @@
+# Calendar Platform — Modular Architecture Design
+
+Status: **Draft** · Supersedes nothing; complements [DESIGN.md](DESIGN.md) (sync
+internals), [MVSR.md](MVSR.md) (strategy/roadmap), [PRD.md](PRD.md) (use cases).
+
+## 1. Motivation
+
+`calendar-sync` began as a single-purpose app (hub-model Google Calendar sync).
+It has since accreted a second, unrelated-but-useful capability — a **Tools** page
+for bulk search/delete of events — and we want to add more calendar utilities
+(starting with the **heatmap**, today a separate Apps Script web app). These tools
+share almost nothing at the feature level but share *everything expensive*: one
+Google OAuth client, one authenticated session, one Calendar API client, one
+deployment. The app is becoming a **calendar workbench**, and its structure should
+say so — without letting the tools trip over each other or over sync.
+
+## 2. Guiding principle
+
+**The architectural boundary is the authenticated calendar substrate, not the
+feature.** Auth + session + Calendar access is costly to duplicate (consent screen,
+token handling, hosting) and cheap to share. Features are the opposite. So we
+consolidate behind one auth substrate and separate features into *modules within
+one app*, rather than into separate apps (which would re-pay the substrate tax) or
+one undifferentiated package (which lets modules entangle).
+
+Target: a **modular monolith**.
+
+## 3. Target architecture
+
+One Go app (appbase: chi router, OAuth, store) hosting cleanly separated modules
+over shared infrastructure.
+
+```
+cmd / main.go                 wiring: build shared infra, mount each module
+internal/
+  platform/                   shared infrastructure (no feature logic)
+    calendar/                 Calendar API client + bulk-ops (batch, concurrency, progress)
+    <auth/session from appbase>
+  sync/                       hub-model sync (background nudge + its data)
+  tools/                      bulk search/delete (and future bulk operations)
+  heatmap/                    read-only weekly-occupancy heatmap
+```
+
+Each **module** is a package that:
+
+- exposes `RegisterRoutes(r chi.Router)` (or equivalent) that `main` mounts under
+  a namespaced path prefix (`/api/tools/...`, `/api/heatmap/...`, `/api/sync/...`);
+- **owns its own store collections** and declares them from the shared `*db.DB`;
+- contributes its own nav entry / page;
+- depends only on **shared infrastructure** (auth/session, the calendar client,
+  the `*db.DB` handle) and, when it genuinely must, on another module's **exported
+  API** — never another module's routes, handlers, or raw collections.
+
+This replaces today's single `internal/app` package with one `Server` god-struct
+and one `Store` owning every collection.
+
+## 4. Data / DB namespacing rules
+
+The cost work taught us that shared, undifferentiated data access is where things
+silently go wrong. Rules:
+
+1. **The `*db.DB` (connection) is shared infrastructure; collections are owned by
+   the module that defines them.** Retire the single all-tables `Store`.
+2. **Collection names are module-prefixed** — `sync_*` (`sync_configs`,
+   `sync_source_calendars`, `sync_synced_events`, `sync_sync_logs`), `tools_*`,
+   etc. The name is the namespace in both backends (Firestore top-level
+   collections, SQLite tables), so the prefix makes ownership greppable and
+   collisions structurally unlikely.
+3. **Cross-module data access goes through the owning module's exported API, never
+   its raw collections.** When `tools` eventually cleans up sync-error placeholders
+   it calls a function `sync` exports, so `sync` can evolve its schema without
+   silently breaking `tools`.
+4. **Cross-cutting identity** (user, session) comes from auth, not any module store.
+
+Heatmap notably owns **no** collections — it is pure Calendar-API read.
+
+## 5. Shared calendar + bulk-ops layer
+
+Both the heatmap (bulk *read*) and bulk-delete (bulk *write*) are instances of the
+same shape: **per-item, network-bound Calendar operations of unbounded size.** They
+need a common home so the plumbing isn't reinvented per tool.
+
+`internal/platform/calendar` provides:
+
+- the authenticated Calendar client (list with field masks + pagination — already
+  the efficient pattern in today's `gcal.go`);
+- **bulk operations** with batching and/or **bounded concurrency**, context
+  cancellation, and rate-limit backoff;
+- a **progress-reporting** contract so callers can surface "N of M done".
+
+Principle to encode: *a bulk calendar operation needs (a) efficient API use (batch
+or bounded concurrency) and (b) an execution model that survives past one request
+timeout, with visible progress.*
+
+## 6. Bulk operations execution model
+
+Today `BulkDeleteEvents` runs Google batch requests **sequentially and
+synchronously inside one HTTP handler** — 500 events = ~10 serial batch round-trips,
+which can exceed a browser/proxy timeout with no progress shown (the observed
+"it hangs / silently times out"). Two changes:
+
+- **Efficiency:** run batches with bounded concurrency (not serially); verify the
+  batch endpoint is actually succeeding (the current multipart-response parsing is
+  fragile) or fall back to bounded-concurrent individual deletes.
+- **Execution model (chosen): client-chunked with progress.** The browser sends
+  deletes in chunks (~50–100) and drives a progress bar; each request is short and
+  can't time out, and the user sees advancement. For a single-user tool this beats a
+  server-side async-job/poll system (no job state to manage). An async job stays a
+  future option if an operation must run detached from any open tab.
+
+## 7. Heatmap: Apps Script → module
+
+Decision: **bring the heatmap into the app as `internal/heatmap`** and retire the
+Apps Script version. Rationale: the Cloud Run pipeline (appconfig, `./dev deploy`,
+CI, code review, real version control, local dev) is far more mature than Apps
+Script's copy-paste workflow, and the incremental infra cost is ~zero because the
+OAuth client, Cloud Run service, and calendar client already exist. The server side
+becomes a thin handler over the shared calendar client's list; the client-side
+aggregation + details panel port over as-is. This also removes the Go/JS
+calendar-logic duplication. (What we give up — Apps Script running "as the user"
+with no token management — is moot; the app already manages that token.)
+
+## 8. Naming / rename — open decision
+
+Consolidation makes `calendar-sync` a partial misnomer. Renaming to an umbrella
+(e.g. `calendar-utilities`) is defensible but carries deployment churn: the OAuth
+client, the `calendar-sync.winser.net` domain, appconfig, and the Cloud Run service
+name. **Recommendation: defer.** Treat the name as cosmetic and decouple it from the
+structural work; schedule a rename on its own if/when the misnomer bothers us. The
+architecture does not depend on it.
+
+## 9. Migration sequencing & risk
+
+| Milestone | Scope | Risk |
+|---|---|---|
+| **M6** | Module foundation + `platform/calendar` bulk-ops layer; extract bulk-delete into `internal/tools`; fix its execution model (client-chunked progress + bounded concurrency). | **Low** — tools is *data-free* today (depends only on token + calendar helpers), so extraction can't corrupt data. Establishes the module/`RegisterRoutes`/namespacing pattern and ships a real UX fix. |
+| **M7** | Heatmap as `internal/heatmap`; nav entry; retire Apps Script. | **Low–med** — read-only, no data; mostly porting + wiring. |
+| **M8** | Move sync into `internal/sync`; migrate its collections to module-owned, prefixed names; retire the god-`Store`. | **High** — touches live production data + the background job. Needs an explicit data-migration plan (collection rename/copy) and a rollback path. Done last, deliberately. |
+
+Order rationale: prove the pattern on the safe, data-free tool first; do the
+data-carrying, background-service module last when the pattern is settled.
+
+## 10. Non-goals
+
+- Multi-tenant / multi-user productization (still a personal, single-user app).
+- A general plugin system — modules are compiled in, not dynamically loaded.
+- Splitting into multiple deployed apps (revisit only on a real forcing function:
+  a different OAuth scope such as Gmail, a different audience, or a heavy/different
+  runtime).
+- Reworking the sync algorithm itself (covered by DESIGN.md; out of scope here).
+
+## 11. Open decisions to confirm
+
+1. Rename now vs. defer (§8) — recommendation: defer.
+2. Collection-name migration for sync in M8: rename-in-place vs. copy-then-cut-over;
+   acceptable downtime, if any.
+3. Bulk-ops progress transport for the client-chunked model: sequential chunked
+   POSTs driven by the browser (simplest) vs. server-sent progress.
+4. Where the heatmap's page assets live (served template vs. embedded static).

--- a/docs/M6-plan.md
+++ b/docs/M6-plan.md
@@ -1,0 +1,192 @@
+# M6 Implementation Plan
+
+## Goal
+
+Establish the modular-monolith foundation from [DESIGN-platform.md](DESIGN-platform.md)
+and prove it on the safest, near-data-free feature: extract **Tools** (bulk
+search/delete) into its own module behind a shared calendar/bulk-ops layer, and fix
+bulk delete for large selections. Sync is left in place (modularized in M8); M6 must
+not change sync behavior or data.
+
+Covers UC-0070 – UC-0074, NFR-06, NFR-07 (documented; exercised in M7/M8).
+
+## Scope boundary
+
+- **In:** the module contract + wiring; a shared `platform/calendar` package (a
+  configurable `Client` + bulk-ops); extracting Tools into `internal/tools`; fixing
+  bulk delete's execution model; fixing token refresh for multi-request operations;
+  establishing the collection-namespacing convention with an explicit M8 mapping.
+- **Out:** moving sync into a module, renaming/migrating collections, rerouting sync's
+  own delete path, the heatmap (M7), the app rename. Sync-specific placeholder logic
+  stays in sync, and sync keeps `BatchDeleteEvents` unchanged.
+
+## Features
+
+### 6.1 Module contract + wiring
+
+A module is a package that exposes two hooks, matching the app's two lifecycle phases
+(API routes register in `setup()` on `a.Router()`; pages register inside
+`SetServeFunc` on `a.Server().Router()`, which runs only for `serve`):
+
+- `RegisterRoutes(deps platform.Deps)` — API routes under `/api/<module>/...`;
+- `RegisterPages(deps platform.Deps)` — authenticated pages via the appbase
+  `LoginPage` wrapper (the `/tools` page uses this today).
+
+`platform.Deps` bundles what a module may depend on: the chi `Router`, `LoginPage`,
+`*db.DB`, and the Google client. A module may also depend on another module's
+**exported API** (see 6.3) — never its routes, handlers, or raw collections.
+
+Auth boundary rule (documented in the contract): appbase applies session auth by the
+`/api/` prefix; routes outside it are unauthenticated by design (as `/sync/nudge` is).
+The existing catch-all `r.Get("/*", …)` coexists with specific page routes via chi
+specificity — the contract notes this so M7's `/heatmap` can rely on it.
+
+`main.go` builds `Deps` once and calls each module's hooks; existing sync/config
+endpoints keep their paths (no client-visible change).
+
+### 6.2 Shared calendar layer (`internal/platform/calendar`)
+
+Carve the *generic* Calendar API surface out of `internal/app/gcal.go`. This is
+mechanical but **not signature-preserving**: today's package-level functions over the
+`calendarAPIBase` const become a **`Client{ BaseURL, HTTP }` struct with methods**, so
+tests can point `BaseURL` at a local fake (see Testing). Every generic call site
+(sync + tools) updates to the client; sync logic and data are unchanged.
+
+- **To `platform/calendar`:**
+  - `Client` with the shared request helper as an exported `Client.Do` — this is where
+    the **classified retry** lives (below), so it fixes retry behavior for *all* callers
+    (search, sync, listing), not just bulk-ops;
+  - `ListEvents` / incremental list, `CreateEvent`, `UpdateEvent`, `DeleteEvent`;
+  - `ListEventsByProperty(ctx, calID, opts)` where `opts` carries private-property
+    filters **and** `timeMin`/`timeMax`/`singleEvents` — so it subsumes all three of
+    today's `ListPlaceholders`, `ListAllPlaceholders`, and `ListPlaceholdersInRange`,
+    and M7's time-windowed heatmap read reuses it. (Resolve in this step the
+    contradiction between `server.go:392` "property + time window don't combine
+    reliably" and `ListPlaceholdersInRange` depending on exactly that; if they do
+    combine, `syncOnly` search should pass the window instead of paging all
+    placeholders and filtering in Go.)
+  - the **bulk-ops** helper (6.4).
+- **Classified retry (in `Client.Do`):** parse the JSON error `reason`; retry only
+  `rateLimitExceeded` / `userRateLimitExceeded` / `quotaExceeded` / `backendError` /
+  429 / 5xx (honor `Retry-After`); **fail fast on other 4xx**. This replaces
+  `doGCalRequestRaw`'s blanket 403-retry (5×/30s), which otherwise hangs on a permanent
+  403 (read-only calendar) everywhere it's used.
+- **Stays with sync:** `BuildPlaceholder`, `IsPlaceholder`, `SourceEventID`, the marker
+  constant, extended-property handling, and `BatchDeleteEvents` + its three call sites
+  (unchanged). `BatchDeleteEvents`/`doBatchDelete` call `Client.Do` and take the
+  configurable `BaseURL` too, so M8 doesn't inherit an untestable sync delete path.
+  Rerouting sync onto bulk-ops (which changes sync-log counts + mid-pass concurrency)
+  is deferred to M8.
+
+Note: 410 Gone is already meaningful here as an expired sync token
+(`ErrSyncTokenExpired`); the idempotent-delete mapping below is scoped to the delete
+path only, not `Client.Do`.
+
+### 6.3 Extract Tools into `internal/tools`
+
+Move `SearchEvents` and `BulkDeleteEvents` plus the `/tools` page/JS into
+`internal/tools`, with its own `RegisterRoutes`/`RegisterPages`. Tools owns **no**
+collections. For the `syncOnly` filter it depends on **sync's exported function**
+`sync.ListSyncPlaceholders(ctx, client, calID)` (exporting a function, not the marker
+constant, keeps sync's schema private per DESIGN §4 rule 3). Behavior preserved (UC-0074).
+
+### 6.4 Fix bulk delete execution model
+
+**Server — bounded, rate-limited, individual deletes** (primary path, not batch): one
+`DELETE` per event → one unambiguous result, so counts are exact by construction
+(UC-0073) with no multipart parser. Controls:
+
+- **Concurrency bound** (~4–8 in flight) **and a shared request-rate limiter**
+  (token bucket, start ~5–10 req/s) — concurrency alone doesn't cap sustained rate, and
+  500 individual deletes will hit per-user write limits without it.
+- **Per-request server deadline** (~30s) and a **partial-result contract**:
+  `{ deleted, failed, unprocessed: [ids] }`. The handler returns what it finished; it
+  never open-endedly blocks. Tune the numeric values against a real 500+ run.
+- **Idempotent success:** 410 Gone (and 404) count as *success* (double-click / re-run).
+- **Token provider, not token string:** bulk-ops takes `func(ctx) (string, error)`;
+  on a 401 it refreshes once and retries the item before counting it failed. This
+  requires the token fix below.
+
+**Token fix (NFR-05, now a deliverable):** `getAccessToken` (`server.go:25`) currently
+returns the *expired* token with `nil` error on refresh failure, and never persists the
+refreshed access token — so every chunk re-refreshes and a failed refresh becomes a
+misleading "N failed". Change it to (a) return an error on refresh failure, and
+(b) persist the refreshed access token to the session (mirror how `TriggerSync`
+persists the refresh token, or confirm the appbase session write-back API).
+
+**Client — chunked with progress:** the browser sends deletions in **sequential**
+chunks (~50–100), re-queuing any `unprocessed` ids from a chunk's partial result,
+driving a progress bar (UC-0072, NFR-06). **Abort after 2 consecutive whole-chunk
+failures** and surface the server's error text (so a permanent 403 stops fast, not
+after all ~10 chunks). The definitive re-search runs **after the last chunk**
+(replacing `setTimeout(searchEvents, 1000)`, which races read-after-write consistency).
+
+### 6.5 Collection-namespacing convention
+
+Rule: **every collection carries its owning module's prefix; add it where missing.**
+Documented in M6; Tools introduces no collections. The current→target mapping for sync
+(executed in M8 against live data):
+
+| Current | Target |
+|---|---|
+| `sync_configs` | `sync_configs` (already prefixed) |
+| `sync_logs` | `sync_logs` (already prefixed) |
+| `source_calendars` | `sync_source_calendars` |
+| `synced_events` | `sync_synced_events` |
+
+NFR-07 is *documented* in M6 and first *exercised* when a module owns namespaced
+collections (M7/M8).
+
+## Data Model Changes
+
+None. Tools is data-free; sync's schema and collections are untouched in M6.
+
+## Build Order
+
+1. **6.2** — `platform/calendar` `Client` (configurable `BaseURL`, `Client.Do` with
+   classified retry, `ListEventsByProperty`); update sync + server call sites; sync
+   stays on `BatchDeleteEvents`. `./dev ci` green, no behavior change beyond retry
+   classification (verify sync tests).
+2. **6.1** — `platform.Deps` + `RegisterRoutes`/`RegisterPages` wiring in `main.go`.
+3. **6.3** — move Tools into `internal/tools`; add `sync.ListSyncPlaceholders`.
+4. **Token fix (6.4)** — `getAccessToken` persistence + error-on-failure; token provider.
+5. **6.4** — bulk-ops (concurrency + rate limit + deadline + partial results + idempotent
+   410), server switch, then client-chunked progress UI.
+6. **6.5** — document the namespacing convention.
+
+Each step compiles and is testable alone; no big-bang integration.
+
+## Testing
+
+- **Prerequisite spike (gates the e2e plan):** confirm whether `AUTH_MODE=dev`
+  (`e2e/03-config.sh`) seeds a Google **access token**. Tools handlers call
+  `getAccessToken`, which 403s when `appbase.AccessToken(r)` is empty. If dev mode seeds
+  none, add an env-injected fake access token to the dev-auth path **before** relying on
+  tools e2e. (If this needs new tooling/appbase changes, raise it explicitly.)
+- **e2e via injectable `BaseURL` → local fake-Google stub:** covers the **server**
+  contract — search (UC-0070/0071), 500+ deletes (UC-0072 server side: chunking, exact
+  counts, 410-as-success, partial results), classified retry, rate limiting.
+- **Honest UC-0072 scope:** the *browser* chunk loop + progress bar is **not** covered
+  by CLI e2e and stays manual, unless we add a headless-browser test — a tooling
+  decision to raise explicitly, not assume.
+- **Unit:** `platform/calendar` bulk-ops with a stub HTTP client — concurrency/rate
+  bounds, retry classification (retry 429/5xx, fail-fast permanent 403), idempotent 410,
+  partial-result shape, exact totals.
+- **e2e (unauthenticated):** `/api/tools/*` exist and reject unauthenticated requests;
+  sync/config endpoints unchanged.
+
+## Risks & validation
+
+- **`gcal.go` → `Client` refactor (6.2)** touches every generic call site (not
+  signature-preserving). Mitigation: compiler + `./dev ci` (incl. sync unit tests);
+  the only intended behavior change is retry classification — verify it doesn't break a
+  sync path that (wrongly) relied on 403-retry.
+- **Batch-endpoint note (correction):** the code uses the still-supported API-specific
+  `…/batch/calendar/v3`, not the retired global `/batch`; today's miscount is a parsing
+  bug. Moot for Tools (moves to individual deletes); relevant only to sync's retained
+  `BatchDeleteEvents`.
+- **Rate/deadline tuning** — start ~5–10 req/s, ~30s deadline, ~50–100 chunk; tune
+  against a real 500+ delete.
+- **Known sync defect for M8 (out of M6 scope):** at all three sync delete sites the
+  `SyncedEvent` record is removed *regardless* of Google-delete success
+  (`sync.go` ~365/591/636), orphaning placeholders. Recorded so M8 fixes it, not inherits it.

--- a/docs/MVSR.md
+++ b/docs/MVSR.md
@@ -64,6 +64,10 @@ Rather than doing pairwise sync across all selected calendars (which scales as O
 - An architecture review agent reviews the plan before implementation begins
 - See `docs/AGENTS.md` for the agent prompt
 
+### Platform Direction
+
+Beyond sync, the app has grown a second useful capability — a **Tools** page for bulk event search/delete — and will gain further calendar utilities (starting with a usage **heatmap**). These tools share little at the feature level but share the *expensive* substrate: one Google OAuth client, one authenticated session, one Calendar client, one deployment. The app is therefore evolving into a **modular calendar workbench** — independent tool modules (sync, tools, heatmap, …) behind shared auth, each owning its own routes and its own data namespace. See [DESIGN-platform.md](DESIGN-platform.md) for the architecture. Splitting into separate deployed apps is reserved for a real forcing function (a different OAuth scope, a different audience, or a heavier runtime), not the default.
+
 ## Roadmap
 
 > This roadmap is illustrative, not the formal engineering or product plan. It shows a reasonable progression of capabilities and outcomes towards the end goal.
@@ -76,3 +80,6 @@ Rather than doing pairwise sync across all selected calendars (which scales as O
 | **M3** | One-way sync from each selected calendar to the hub calendar. Sync handles creation, update, and deletion of events. |
 | **M4** | Two-way sync from the hub to each calendar. Sync correctly propagates creation, update, and deletion of events from the original calendar to the hub and then onwards to all calendars. |
 | **M5** | Polish and enhancements as determined during development. |
+| **M6** | Modular foundation: extract the Tools (bulk search/delete) into its own module behind a shared calendar/bulk-ops layer, and fix bulk delete for large selections (client-chunked progress, bounded concurrency). |
+| **M7** | Heatmap module: bring the weekly-occupancy heatmap into the app (read-only), retiring the standalone Apps Script version. |
+| **M8** | Modularize sync into its own module and migrate its data to module-owned, prefixed collections; retire the shared all-tables store. |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -86,6 +86,18 @@ Calendar Sync keeps a user's free/busy status consistent across multiple Google 
 | UC-0059 | Per-calendar sync log | Sync logs include per-calendar breakdowns of created/updated/deleted counts, shown in the UI. |
 | UC-0060 | Hub change cleans up old hub | When the hub calendar is changed, the next sync pass deletes all placeholder events from the old hub and removes outbound placeholders on source calendars that were synced from the old hub. Corresponding SyncedEvent records are cleaned up. |
 
+### M6 — Modular Tools and Bulk Operations
+
+The Tools feature (bulk search/delete) predates formal use-case coverage; M6 captures its behavior, moves it into its own module, and fixes bulk delete for large selections. Definitions: a **tool** is a self-contained utility module behind the shared auth (own routes, own data namespace); **bulk operation** is a Calendar action applied to many events in one user request.
+
+| ID | Use Case | Description |
+|----|----------|-------------|
+| UC-0070 | Search events on a calendar | An authenticated user searches a chosen calendar for events matching filters (time range, title substring), and receives the matching events (id, title, start/end). |
+| UC-0071 | Bulk delete selected events | The user selects events from search results and deletes them in one action. The operation reports how many were deleted and how many failed. |
+| UC-0072 | Large bulk delete completes with progress | Deleting a large selection (500+ events) completes reliably with visible progress and without a silent request timeout. |
+| UC-0073 | Accurate bulk-delete result reporting | When some deletes fail, the reported deleted/failed counts are accurate (no miscount from response parsing). |
+| UC-0074 | Tool served from its own module | The Tools feature is served from an isolated module with its own routes (`/api/tools/...`) and owns no shared sync data; extracting it preserves existing behavior. |
+
 ## Future Considerations
 
 The following are not in the current roadmap but are anticipated extensions:
@@ -107,7 +119,9 @@ The following are not in the current roadmap but are anticipated extensions:
 | NFR-02 | The app runs on localhost, TrueNAS (Docker), and Cloud Run without code changes — only configuration differs. |
 | NFR-03 | All state is stored in SQLite (local/TrueNAS) or Firestore (Cloud Run). No other persistence dependencies. |
 | NFR-04 | The app handles Google Calendar API rate limits gracefully (exponential backoff, no data loss). |
-| NFR-05 | OAuth token refresh is handled transparently — a sync pass does not fail due to an expired access token if a valid refresh token exists. |
+| NFR-05 | OAuth token refresh is handled transparently — a sync pass or bulk operation does not fail due to an expired access token if a valid refresh token exists, including across a multi-request bulk operation. |
+| NFR-06 | Bulk operations over many events complete without exceeding request timeouts and surface progress to the user, rather than appearing to hang. |
+| NFR-07 | Each tool module owns its own store collections under a module-prefixed namespace; modules access another module's data only through its exported API, never its raw collections. |
 
 ## Use Case Status
 
@@ -119,4 +133,5 @@ Track implementation status here. E2e tests for all "done" use cases must pass i
 | M2 | UC-0010 – UC-0016 | done (UC-0010 manual only) |
 | M3 | UC-0020 – UC-0034 | done (UC-0020–UC-0028, UC-0031–UC-0034 manual only) |
 | M4 | UC-0040 – UC-0049 | done (UC-0040–UC-0049 manual only) |
-| M5 | UC-0050 – UC-0060 | not started |
+| M5 | UC-0050 – UC-0060 | implemented (manual only); e2e status audit pending |
+| M6 | UC-0070 – UC-0074 | not started |


### PR DESCRIPTION
Design docs for evolving calendar-sync into a modular calendar workbench (tool modules behind shared auth), plus the M6 implementation plan.

## Contents
- **DESIGN-platform.md** (new) — architecture: the auth-substrate boundary, modular-monolith layout, module contract, DB-namespacing rules, shared `platform/calendar` bulk-ops layer, bulk-op execution model, heatmap-into-app decision, rename deferred, and M6→M7→M8 sequencing with risk.
- **MVSR.md** — Platform Direction subsection + M6–M8 roadmap.
- **PRD.md** — UC-0070..0074 (formalizes the previously-uncovered Tools feature), NFR-06/07, corrected M5 status.
- **M6-plan.md** (new) — extract Tools into `internal/tools` behind `platform/calendar`; fix bulk delete (bounded-concurrent + rate-limited individual deletes, idempotent 410, classified retry, chunked client progress + partial results).

## Process
Ran the project's architecture-review agent twice (REVISE → APPROVE WITH CHANGES); all BLOCKING items folded in. Notably it surfaced a real bug in existing `getAccessToken` (returns the expired token on refresh failure, never persists the refreshed one) — now an M6 deliverable.

Docs only — no code changes. Deployed `v1.1.0` (cost-optimization release) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)