### PR TITLE
M6 step 1: extract generic Calendar client into platform/calendar

### DIFF
--- a/internal/app/gcal.go
+++ b/internal/app/gcal.go
@@ -1,544 +1,54 @@
 package app
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"math/rand"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+
+	"github.com/michaelwinser/calendar-sync/internal/platform/calendar"
 )
 
-const calendarAPIBase = "https://www.googleapis.com/calendar/v3"
+// The generic Google Calendar client and types live in platform/calendar. These
+// aliases keep existing app code (sync, handlers, tests) referring to the short
+// names; the sync-specific placeholder logic below stays here until M8 moves it
+// into an internal/sync module.
+type (
+	Calendar           = calendar.Calendar
+	GCalEvent          = calendar.GCalEvent
+	EventTime          = calendar.EventTime
+	Attendee           = calendar.Attendee
+	Reminders          = calendar.Reminders
+	ExtendedProperties = calendar.ExtendedProperties
+	ListEventsResult   = calendar.ListEventsResult
+)
 
-// Calendar represents a Google Calendar from the CalendarList API.
-type Calendar struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Primary    bool   `json:"primary"`
-	AccessRole string `json:"accessRole"`
-}
+// ErrSyncTokenExpired re-exports the client's sentinel for existing call sites.
+var ErrSyncTokenExpired = calendar.ErrSyncTokenExpired
 
-// GCalEvent represents a Google Calendar event with the fields we read and write.
-type GCalEvent struct {
-	ID                 string             `json:"id,omitempty"`
-	Summary            string             `json:"summary,omitempty"`
-	Description        string             `json:"description,omitempty"`
-	Location           string             `json:"location,omitempty"`
-	Start              EventTime          `json:"start"`
-	End                EventTime          `json:"end"`
-	Status             string             `json:"status,omitempty"`
-	Transparency       string             `json:"transparency,omitempty"` // "opaque" (default/empty) or "transparent" (free)
-	ConferenceData     json.RawMessage    `json:"conferenceData,omitempty"`
-	Attachments        json.RawMessage    `json:"attachments,omitempty"`
-	Attendees          []Attendee         `json:"attendees,omitempty"`
-	Reminders          *Reminders         `json:"reminders,omitempty"`
-	ExtendedProperties *ExtendedProperties `json:"extendedProperties,omitempty"`
-	ColorID            string             `json:"colorId,omitempty"`
-	Updated            string             `json:"updated,omitempty"`
-	RecurringEventId   string             `json:"recurringEventId,omitempty"`
-	EventType          string             `json:"eventType,omitempty"` // default, workingLocation, outOfOffice, focusTime
-}
+// IsDeclined reports whether the authenticated user declined the event.
+func IsDeclined(event GCalEvent) bool { return calendar.IsDeclined(event) }
 
-// EventTime represents a Google Calendar event time (either dateTime or date for all-day).
-type EventTime struct {
-	DateTime string `json:"dateTime,omitempty"`
-	Date     string `json:"date,omitempty"`
-	TimeZone string `json:"timeZone,omitempty"`
-}
+// FormatAttendees formats an attendee list as a human-readable string.
+func FormatAttendees(attendees []Attendee) string { return calendar.FormatAttendees(attendees) }
 
-// Attendee represents a Google Calendar event attendee.
-type Attendee struct {
-	Email          string `json:"email"`
-	DisplayName    string `json:"displayName,omitempty"`
-	Self           bool   `json:"self,omitempty"`
-	ResponseStatus string `json:"responseStatus,omitempty"`
-	Organizer      bool   `json:"organizer,omitempty"`
-}
-
-// Reminders controls event reminder settings.
-type Reminders struct {
-	UseDefault bool `json:"useDefault"`
-}
-
-// ExtendedProperties holds private and shared key-value pairs on an event.
-type ExtendedProperties struct {
-	Private map[string]string `json:"private,omitempty"`
-}
-
-// eventsListResponse is the Google Calendar events.list response.
-type eventsListResponse struct {
-	Items         []GCalEvent `json:"items"`
-	NextPageToken string      `json:"nextPageToken"`
-	NextSyncToken string      `json:"nextSyncToken"`
-}
-
-// calendarListResponse is the Google Calendar calendarList.list response.
-type calendarListResponse struct {
-	Items []struct {
-		ID              string `json:"id"`
-		Summary         string `json:"summary"`
-		SummaryOverride string `json:"summaryOverride"`
-		Primary         bool   `json:"primary"`
-		AccessRole      string `json:"accessRole"`
-	} `json:"items"`
-	NextPageToken string `json:"nextPageToken"`
-}
-
-// --- Calendar list ---
-
-// ListCalendars fetches the user's calendar list from Google Calendar API.
-func ListCalendars(ctx context.Context, token string) ([]Calendar, error) {
-	var all []Calendar
-	pageToken := ""
-
-	for {
-		u := calendarAPIBase + "/users/me/calendarList?maxResults=100"
-		if pageToken != "" {
-			u += "&pageToken=" + pageToken
-		}
-
-		body, err := doGCalRequest(ctx, token, "GET", u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("listing calendars: %w", err)
-		}
-
-		var list calendarListResponse
-		if err := json.Unmarshal(body, &list); err != nil {
-			return nil, fmt.Errorf("decoding calendar list: %w", err)
-		}
-
-		for _, item := range list.Items {
-			name := item.SummaryOverride
-			if name == "" {
-				name = item.Summary
-			}
-			all = append(all, Calendar{
-				ID:         item.ID,
-				Name:       name,
-				Primary:    item.Primary,
-				AccessRole: item.AccessRole,
-			})
-		}
-
-		if list.NextPageToken == "" {
-			break
-		}
-		pageToken = list.NextPageToken
-	}
-
-	return all, nil
-}
-
-// --- Event operations ---
-
-// ListEventsResult holds events and the sync token from a list call.
-type ListEventsResult struct {
-	Events    []GCalEvent
-	SyncToken string
-}
-
-// ErrSyncTokenExpired is returned when the sync token is no longer valid (410 Gone).
-var ErrSyncTokenExpired = fmt.Errorf("sync token expired (410 Gone)")
-
-// ListEvents fetches events from a calendar within the given time window.
-// Returns events and a sync token for future incremental fetches.
-func ListEvents(ctx context.Context, token, calendarID string, timeMin, timeMax time.Time) (*ListEventsResult, error) {
-	var result ListEventsResult
-	pageToken := ""
-
-	for {
-		params := url.Values{}
-		params.Set("singleEvents", "true")
-		params.Set("orderBy", "startTime")
-		params.Set("maxResults", "2500")
-		params.Set("timeMin", timeMin.Format(time.RFC3339))
-		params.Set("timeMax", timeMax.Format(time.RFC3339))
-		if pageToken != "" {
-			params.Set("pageToken", pageToken)
-		}
-
-		u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
-		body, err := doGCalRequest(ctx, token, "GET", u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("listing events: %w", err)
-		}
-
-		var resp eventsListResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("decoding events: %w", err)
-		}
-
-		result.Events = append(result.Events, resp.Items...)
-
-		if resp.NextPageToken == "" {
-			result.SyncToken = resp.NextSyncToken
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return &result, nil
-}
-
-// ListEventsIncremental fetches only events changed since the given sync token.
-// Returns ErrSyncTokenExpired if the token is no longer valid.
-func ListEventsIncremental(ctx context.Context, token, calendarID, syncToken string) (*ListEventsResult, error) {
-	var result ListEventsResult
-	pageToken := ""
-
-	for {
-		params := url.Values{}
-		params.Set("syncToken", syncToken)
-		if pageToken != "" {
-			params.Set("pageToken", pageToken)
-		}
-
-		u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
-		body, statusCode, err := doGCalRequestRaw(ctx, token, "GET", u, nil)
-		if statusCode == http.StatusGone {
-			return nil, ErrSyncTokenExpired
-		}
-		if err != nil {
-			return nil, fmt.Errorf("incremental sync: %w", err)
-		}
-
-		var resp eventsListResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("decoding incremental events: %w", err)
-		}
-
-		result.Events = append(result.Events, resp.Items...)
-
-		if resp.NextPageToken == "" {
-			result.SyncToken = resp.NextSyncToken
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return &result, nil
-}
+// --- Sync-specific: placeholder marker, queries, and construction ---
 
 // ListPlaceholders fetches placeholder events on a calendar for a specific source.
-func ListPlaceholders(ctx context.Context, token, calendarID, sourceCalendarID string) ([]GCalEvent, error) {
-	var all []GCalEvent
-	pageToken := ""
-
-	for {
-		params := url.Values{}
-		params.Add("privateExtendedProperty", "calendarSyncMarker=v1")
-		params.Add("privateExtendedProperty", "sourceCalendarId="+sourceCalendarID)
-		params.Set("singleEvents", "true")
-		params.Set("maxResults", "2500")
-		if pageToken != "" {
-			params.Set("pageToken", pageToken)
-		}
-
-		u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
-		body, err := doGCalRequest(ctx, token, "GET", u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("listing placeholders: %w", err)
-		}
-
-		var resp eventsListResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("decoding placeholders: %w", err)
-		}
-
-		all = append(all, resp.Items...)
-
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return all, nil
-}
-
-// ListPlaceholdersInRange fetches sync-engine placeholders within a time window.
-func ListPlaceholdersInRange(ctx context.Context, token, calendarID string, timeMin, timeMax time.Time) ([]GCalEvent, error) {
-	var all []GCalEvent
-	pageToken := ""
-
-	for {
-		params := url.Values{}
-		params.Set("privateExtendedProperty", "calendarSyncMarker=v1")
-		params.Set("singleEvents", "true")
-		params.Set("maxResults", "2500")
-		params.Set("timeMin", timeMin.Format(time.RFC3339))
-		params.Set("timeMax", timeMax.Format(time.RFC3339))
-		if pageToken != "" {
-			params.Set("pageToken", pageToken)
-		}
-
-		u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
-		body, err := doGCalRequest(ctx, token, "GET", u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("listing placeholders in range: %w", err)
-		}
-
-		var resp eventsListResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("decoding placeholders: %w", err)
-		}
-
-		all = append(all, resp.Items...)
-
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return all, nil
+func ListPlaceholders(ctx context.Context, cal *calendar.Client, token, calendarID, sourceCalendarID string) ([]GCalEvent, error) {
+	return cal.ListEventsByProperty(ctx, token, calendarID, calendar.EventQuery{
+		PrivateProps: map[string]string{
+			"calendarSyncMarker": "v1",
+			"sourceCalendarId":   sourceCalendarID,
+		},
+		SingleEvents: true,
+	})
 }
 
 // ListAllPlaceholders fetches all placeholder events created by this app on a calendar.
-func ListAllPlaceholders(ctx context.Context, token, calendarID string) ([]GCalEvent, error) {
-	var all []GCalEvent
-	pageToken := ""
-
-	for {
-		params := url.Values{}
-		params.Set("privateExtendedProperty", "calendarSyncMarker=v1")
-		params.Set("singleEvents", "true")
-		params.Set("maxResults", "2500")
-		if pageToken != "" {
-			params.Set("pageToken", pageToken)
-		}
-
-		u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
-		body, err := doGCalRequest(ctx, token, "GET", u, nil)
-		if err != nil {
-			return nil, fmt.Errorf("listing all placeholders: %w", err)
-		}
-
-		var resp eventsListResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("decoding placeholders: %w", err)
-		}
-
-		all = append(all, resp.Items...)
-
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-
-	return all, nil
+func ListAllPlaceholders(ctx context.Context, cal *calendar.Client, token, calendarID string) ([]GCalEvent, error) {
+	return cal.ListEventsByProperty(ctx, token, calendarID, calendar.EventQuery{
+		PrivateProps: map[string]string{"calendarSyncMarker": "v1"},
+		SingleEvents: true,
+	})
 }
-
-// CreateEvent creates an event on the specified calendar.
-func CreateEvent(ctx context.Context, token, calendarID string, event *GCalEvent) (*GCalEvent, error) {
-	u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) +
-		"/events?conferenceDataVersion=1&supportsAttachments=true&sendUpdates=none"
-
-	jsonBody, err := json.Marshal(event)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := doGCalRequest(ctx, token, "POST", u, jsonBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating event: %w", err)
-	}
-
-	var created GCalEvent
-	if err := json.Unmarshal(body, &created); err != nil {
-		return nil, fmt.Errorf("decoding created event: %w", err)
-	}
-	return &created, nil
-}
-
-// UpdateEvent patches an event on the specified calendar.
-func UpdateEvent(ctx context.Context, token, calendarID, eventID string, event *GCalEvent) (*GCalEvent, error) {
-	u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) +
-		"/events/" + url.PathEscape(eventID) +
-		"?conferenceDataVersion=1&supportsAttachments=true&sendUpdates=none"
-
-	jsonBody, err := json.Marshal(event)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := doGCalRequest(ctx, token, "PATCH", u, jsonBody)
-	if err != nil {
-		return nil, fmt.Errorf("updating event: %w", err)
-	}
-
-	var updated GCalEvent
-	if err := json.Unmarshal(body, &updated); err != nil {
-		return nil, fmt.Errorf("decoding updated event: %w", err)
-	}
-	return &updated, nil
-}
-
-// DeleteEvent deletes an event from the specified calendar.
-func DeleteEvent(ctx context.Context, token, calendarID, eventID string) error {
-	u := calendarAPIBase + "/calendars/" + url.PathEscape(calendarID) +
-		"/events/" + url.PathEscape(eventID) + "?sendUpdates=none"
-
-	_, err := doGCalRequest(ctx, token, "DELETE", u, nil)
-	return err
-}
-
-// BatchDeleteEvents deletes multiple events using Google's batch API.
-// Processes up to 50 events per batch request. Returns counts of deleted and errored.
-func BatchDeleteEvents(ctx context.Context, token, calendarID string, eventIDs []string) (deleted, errors int) {
-	const batchSize = 50
-
-	for i := 0; i < len(eventIDs); i += batchSize {
-		end := i + batchSize
-		if end > len(eventIDs) {
-			end = len(eventIDs)
-		}
-		chunk := eventIDs[i:end]
-
-		d, e := doBatchDelete(ctx, token, calendarID, chunk)
-		deleted += d
-		errors += e
-	}
-	return
-}
-
-func doBatchDelete(ctx context.Context, token, calendarID string, eventIDs []string) (deleted, errors int) {
-	boundary := "batch_calsync_" + fmt.Sprintf("%d", time.Now().UnixNano())
-
-	var body bytes.Buffer
-	for i, eventID := range eventIDs {
-		body.WriteString("--" + boundary + "\r\n")
-		body.WriteString("Content-Type: application/http\r\n")
-		body.WriteString(fmt.Sprintf("Content-ID: <item%d>\r\n", i))
-		body.WriteString("\r\n")
-
-		path := "/calendar/v3/calendars/" + url.PathEscape(calendarID) +
-			"/events/" + url.PathEscape(eventID) + "?sendUpdates=none"
-		body.WriteString("DELETE " + path + " HTTP/1.1\r\n")
-		body.WriteString("\r\n")
-	}
-	body.WriteString("--" + boundary + "--\r\n")
-
-	req, err := http.NewRequestWithContext(ctx, "POST",
-		"https://www.googleapis.com/batch/calendar/v3", &body)
-	if err != nil {
-		return 0, len(eventIDs)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "multipart/mixed; boundary="+boundary)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return 0, len(eventIDs)
-	}
-	respBody, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, len(eventIDs)
-	}
-
-	// Parse multipart response to count successes/failures.
-	// Each part has an HTTP status line like "HTTP/1.1 204 No Content"
-	respStr := string(respBody)
-	for _, id := range eventIDs {
-		_ = id
-		// Count HTTP 204 (success) and HTTP 200 (success) responses
-	}
-	// Simple approach: count "HTTP/1.1 204" and "HTTP/1.1 200" occurrences
-	for _, line := range strings.Split(respStr, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "HTTP/1.1 2") {
-			deleted++
-		} else if strings.HasPrefix(line, "HTTP/1.1 4") || strings.HasPrefix(line, "HTTP/1.1 5") {
-			errors++
-		}
-	}
-
-	return
-}
-
-// --- HTTP helpers with retry ---
-
-// doGCalRequest makes an API request with exponential backoff on 403/429.
-func doGCalRequest(ctx context.Context, token, method, url string, body []byte) ([]byte, error) {
-	respBody, statusCode, err := doGCalRequestRaw(ctx, token, method, url, body)
-	if err != nil {
-		return nil, err
-	}
-	if statusCode >= 400 {
-		return nil, fmt.Errorf("API status %d: %s", statusCode, string(respBody))
-	}
-	return respBody, nil
-}
-
-// doGCalRequestRaw makes an API request with retry, returning the body and status code.
-// Caller is responsible for checking status code for specific handling (e.g., 410 Gone).
-func doGCalRequestRaw(ctx context.Context, token, method, rawURL string, reqBody []byte) ([]byte, int, error) {
-	const maxRetries = 5
-	baseDelay := 500 * time.Millisecond
-	maxDelay := 30 * time.Second
-
-	for attempt := range maxRetries {
-		var bodyReader io.Reader
-		if reqBody != nil {
-			bodyReader = bytes.NewReader(reqBody)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, method, rawURL, bodyReader)
-		if err != nil {
-			return nil, 0, err
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-		if reqBody != nil {
-			req.Header.Set("Content-Type", "application/json")
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return nil, 0, fmt.Errorf("request failed: %w", err)
-		}
-
-		respBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, 0, fmt.Errorf("reading response: %w", err)
-		}
-
-		// Retry on rate limit or server error
-		if (resp.StatusCode == 403 || resp.StatusCode == 429 || resp.StatusCode >= 500) && attempt < maxRetries-1 {
-			delay := baseDelay * time.Duration(1<<attempt)
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-			// Jitter ±25%
-			jitter := time.Duration(float64(delay) * (0.75 + rand.Float64()*0.5))
-			select {
-			case <-ctx.Done():
-				return nil, 0, ctx.Err()
-			case <-time.After(jitter):
-			}
-			continue
-		}
-
-		// For DELETE, 204 No Content is success
-		if method == "DELETE" && resp.StatusCode == http.StatusNoContent {
-			return nil, resp.StatusCode, nil
-		}
-
-		return respBody, resp.StatusCode, nil
-	}
-
-	return nil, 0, fmt.Errorf("max retries exceeded")
-}
-
-// --- Helpers ---
 
 // IsPlaceholder returns true if the event was created by the sync engine.
 func IsPlaceholder(event GCalEvent) bool {
@@ -548,40 +58,12 @@ func IsPlaceholder(event GCalEvent) bool {
 	return event.ExtendedProperties.Private["calendarSyncMarker"] == "v1"
 }
 
-// IsDeclined returns true if the authenticated user has declined this event.
-func IsDeclined(event GCalEvent) bool {
-	for _, a := range event.Attendees {
-		if a.Self && a.ResponseStatus == "declined" {
-			return true
-		}
-	}
-	return false
-}
-
 // SourceEventID returns the source event ID from a placeholder's extended properties.
 func SourceEventID(event GCalEvent) string {
 	if event.ExtendedProperties == nil {
 		return ""
 	}
 	return event.ExtendedProperties.Private["sourceEventId"]
-}
-
-// FormatAttendees formats an attendee list as a human-readable string.
-func FormatAttendees(attendees []Attendee) string {
-	var parts []string
-	for _, a := range attendees {
-		name := a.DisplayName
-		if name == "" {
-			name = a.Email
-		} else {
-			name += " <" + a.Email + ">"
-		}
-		if a.Organizer {
-			name += " (organizer)"
-		}
-		parts = append(parts, name)
-	}
-	return strings.Join(parts, ", ")
 }
 
 // PlaceholderOptions configures how a placeholder event looks on the target calendar.
@@ -606,15 +88,15 @@ func BuildPlaceholder(source GCalEvent, sourceCalID string, opts PlaceholderOpti
 	}
 
 	p := GCalEvent{
-		Summary:      summary,
-		Description:  desc,
-		Location:     source.Location,
-		Start:        source.Start,
-		End:          source.End,
-		Transparency: source.Transparency, // empty means "opaque" (busy) — the API default
+		Summary:        summary,
+		Description:    desc,
+		Location:       source.Location,
+		Start:          source.Start,
+		End:            source.End,
+		Transparency:   source.Transparency, // empty means "opaque" (busy) — the API default
 		ConferenceData: source.ConferenceData,
 		Attachments:    source.Attachments,
-		Reminders:    &Reminders{UseDefault: false},
+		Reminders:      &Reminders{UseDefault: false},
 		ExtendedProperties: &ExtendedProperties{
 			Private: map[string]string{
 				"calendarSyncMarker": "v1",
@@ -625,7 +107,6 @@ func BuildPlaceholder(source GCalEvent, sourceCalID string, opts PlaceholderOpti
 	}
 
 	if opts.ColorID == "source" {
-		// Use the source event's color (if it has one)
 		p.ColorID = source.ColorID
 	} else if opts.ColorID != "" {
 		p.ColorID = opts.ColorID

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -13,12 +13,14 @@ import (
 	"github.com/michaelwinser/appbase"
 	"github.com/michaelwinser/appbase/auth"
 	"github.com/michaelwinser/appbase/server"
+	"github.com/michaelwinser/calendar-sync/internal/platform/calendar"
 )
 
 // Server handles API requests.
 type Server struct {
 	Store  *Store
 	Google *auth.GoogleAuth
+	Cal    *calendar.Client
 }
 
 // getAccessToken returns the OAuth access token, refreshing if expired.
@@ -87,7 +89,7 @@ func (s *Server) ListCalendars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	calendars, err := ListCalendars(r.Context(), token)
+	calendars, err := s.Cal.ListCalendars(r.Context(), token)
 	if err != nil {
 		server.RespondError(w, http.StatusBadGateway, "Google Calendar API: "+err.Error())
 		return
@@ -281,7 +283,7 @@ func (s *Server) TriggerSync(w http.ResponseWriter, r *http.Request) {
 	}
 	dryRun := r.URL.Query().Get("dryRun") == "true"
 
-	result, err := RunSyncWithOptions(r.Context(), token, s.Store, cfg, sources, SyncOptions{
+	result, err := RunSyncWithOptions(r.Context(), s.Cal, token, s.Store, cfg, sources, SyncOptions{
 		SyncDays: syncDays,
 		DryRun:   dryRun,
 	})
@@ -391,7 +393,7 @@ func (s *Server) SearchEvents(w http.ResponseWriter, r *http.Request) {
 	if syncOnly {
 		// Fetch all sync-engine placeholders, then filter by date client-side.
 		// (privateExtendedProperty + timeMin/timeMax don't combine reliably in the API)
-		all, err := ListAllPlaceholders(r.Context(), token, calendarID)
+		all, err := ListAllPlaceholders(r.Context(), s.Cal, token, calendarID)
 		if err != nil {
 			server.RespondError(w, http.StatusBadGateway, "Google Calendar API: "+err.Error())
 			return
@@ -414,7 +416,7 @@ func (s *Server) SearchEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		res, err := ListEvents(r.Context(), token, calendarID, timeMin, timeMax)
+		res, err := s.Cal.ListEvents(r.Context(), token, calendarID, timeMin, timeMax)
 		if err != nil {
 			server.RespondError(w, http.StatusBadGateway, "Google Calendar API: "+err.Error())
 			return
@@ -485,7 +487,7 @@ func (s *Server) BulkDeleteEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deleted, errors := BatchDeleteEvents(r.Context(), token, req.CalendarID, req.EventIDs)
+	deleted, errors := s.Cal.BatchDeleteEvents(r.Context(), token, req.CalendarID, req.EventIDs)
 
 	server.RespondJSON(w, http.StatusOK, map[string]interface{}{
 		"deleted": deleted,
@@ -563,7 +565,7 @@ func (s *Server) NudgeSync(w http.ResponseWriter, r *http.Request) {
 		// Allow zero sources — cleanup phase needs to run
 
 		syncDays := cfg.SyncWindowWeeks * 7
-		if _, err := RunSyncWithDays(r.Context(), token, s.Store, &cfg, sources, syncDays); err != nil {
+		if _, err := RunSyncWithDays(r.Context(), s.Cal, token, s.Store, &cfg, sources, syncDays); err != nil {
 			msg := fmt.Sprintf("user %s: sync failed: %v", cfg.UserID, err)
 			log.Printf("nudge: %s", msg)
 			errs = append(errs, msg)

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"strings"
 	"time"
+
+	"github.com/michaelwinser/calendar-sync/internal/platform/calendar"
 )
 
 // hubEvent represents a placeholder on the hub with its source metadata.
@@ -60,17 +62,17 @@ type SyncOptions struct {
 }
 
 // RunSync executes a full sync pass using the configured sync window.
-func RunSync(ctx context.Context, token string, store *Store, config *SyncConfig, sources []SourceCalendar) (*SyncResult, error) {
-	return RunSyncWithOptions(ctx, token, store, config, sources, SyncOptions{})
+func RunSync(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, sources []SourceCalendar) (*SyncResult, error) {
+	return RunSyncWithOptions(ctx, cal, token, store, config, sources, SyncOptions{})
 }
 
 // RunSyncWithDays executes a full sync pass with an explicit window in days.
-func RunSyncWithDays(ctx context.Context, token string, store *Store, config *SyncConfig, sources []SourceCalendar, syncDays int) (*SyncResult, error) {
-	return RunSyncWithOptions(ctx, token, store, config, sources, SyncOptions{SyncDays: syncDays})
+func RunSyncWithDays(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, sources []SourceCalendar, syncDays int) (*SyncResult, error) {
+	return RunSyncWithOptions(ctx, cal, token, store, config, sources, SyncOptions{SyncDays: syncDays})
 }
 
 // RunSyncWithOptions executes a full sync pass with explicit options.
-func RunSyncWithOptions(ctx context.Context, token string, store *Store, config *SyncConfig, sources []SourceCalendar, opts SyncOptions) (*SyncResult, error) {
+func RunSyncWithOptions(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, sources []SourceCalendar, opts SyncOptions) (*SyncResult, error) {
 	readsBefore := store.Reads()
 	syncDays := opts.SyncDays
 	if syncDays <= 0 {
@@ -116,7 +118,7 @@ func RunSyncWithOptions(ctx context.Context, token string, store *Store, config 
 	// Phase 1: Inbound — sync each source calendar to the hub
 	for _, source := range sources {
 		c0, u0, d0 := snapshot()
-		err := syncSourceToHub(ctx, token, store, config, &source, syncDays, dryRun, result)
+		err := syncSourceToHub(ctx, cal, token, store, config, &source, syncDays, dryRun, result)
 		recordDelta(source.CalendarName, c0, u0, d0)
 		if err != nil {
 			result.addError("inbound sync error for %s: %v", source.CalendarName, err)
@@ -127,7 +129,7 @@ func RunSyncWithOptions(ctx context.Context, token string, store *Store, config 
 	// Note: newly created/deleted hub events from Phase 1 may not be visible
 	// to the API yet due to eventual consistency. They will propagate on the
 	// next sync pass. This is an accepted trade-off.
-	if err := syncHubToSources(ctx, token, store, config, sources, dryRun, result); err != nil {
+	if err := syncHubToSources(ctx, cal, token, store, config, sources, dryRun, result); err != nil {
 		result.addError("outbound sync error: %v", err)
 	}
 
@@ -141,12 +143,12 @@ func RunSyncWithOptions(ctx context.Context, token string, store *Store, config 
 			result.addError("cleanup: failed to load synced events: %v", err)
 		} else {
 			// Phase 3: delete placeholders for removed source calendars
-			cleanupRemovedSources(ctx, token, store, sources, allSynced, result)
+			cleanupRemovedSources(ctx, cal, token, store, sources, allSynced, result)
 			// Phase 4: delete placeholders for past events. allSynced is the
 			// pre-Phase-3 snapshot, so it may still list records Phase 3 just
 			// deleted — harmless: the placeholder scan comes fresh from the API,
 			// and DeleteSyncedEvent on an already-removed ID is a no-op.
-			cleanupPastEvents(ctx, token, store, config, sources, allSynced, result)
+			cleanupPastEvents(ctx, cal, token, store, config, sources, allSynced, result)
 		}
 	}
 
@@ -195,7 +197,7 @@ func RunSyncWithOptions(ctx context.Context, token string, store *Store, config 
 	return result, nil
 }
 
-func syncSourceToHub(ctx context.Context, token string, store *Store, config *SyncConfig, source *SourceCalendar, syncDays int, dryRun bool, result *SyncResult) error {
+func syncSourceToHub(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, source *SourceCalendar, syncDays int, dryRun bool, result *SyncResult) error {
 	hubCalID := config.HubCalendarID
 
 	now := time.Now().UTC()
@@ -207,7 +209,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 	var newSyncToken string
 
 	if source.SyncToken != "" {
-		res, err := ListEventsIncremental(ctx, token, source.CalendarID, source.SyncToken)
+		res, err := cal.ListEventsIncremental(ctx, token, source.CalendarID, source.SyncToken)
 		if errors.Is(err, ErrSyncTokenExpired) {
 			log.Printf("sync token expired for %s, falling back to full sync", source.CalendarName)
 			source.SyncToken = ""
@@ -222,7 +224,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 
 	if source.SyncToken == "" {
 		// Full sync
-		res, err := ListEvents(ctx, token, source.CalendarID, timeMin, timeMax)
+		res, err := cal.ListEvents(ctx, token, source.CalendarID, timeMin, timeMax)
 		if err != nil {
 			return fmt.Errorf("fetching events from %s: %w", source.CalendarName, err)
 		}
@@ -231,7 +233,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 	}
 
 	// 2. Fetch existing placeholders on hub for this source
-	placeholders, err := ListPlaceholders(ctx, token, hubCalID, source.CalendarID)
+	placeholders, err := ListPlaceholders(ctx, cal, token, hubCalID, source.CalendarID)
 	if err != nil {
 		return fmt.Errorf("fetching placeholders for %s: %w", source.CalendarName, err)
 	}
@@ -305,7 +307,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 				result.Created++
 				continue
 			}
-			created, err := CreateEvent(ctx, token, hubCalID, &placeholder)
+			created, err := cal.CreateEvent(ctx, token, hubCalID, &placeholder)
 			if err != nil {
 				result.addError("failed to create placeholder for %s: %v", event.Summary, err)
 				continue
@@ -329,7 +331,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 				result.Updated++
 				continue
 			}
-			_, err := UpdateEvent(ctx, token, hubCalID, existingSynced.TargetEventID, &placeholder)
+			_, err := cal.UpdateEvent(ctx, token, hubCalID, existingSynced.TargetEventID, &placeholder)
 			if err != nil {
 				if isNotFoundError(err) {
 					log.Printf("placeholder for %s was deleted, will recreate next pass", event.Summary)
@@ -362,7 +364,7 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 				deleteIDs = append(deleteIDs, se.TargetEventID)
 				deleteRecords = append(deleteRecords, se)
 			}
-			deleted, errs := BatchDeleteEvents(ctx, token, hubCalID, deleteIDs)
+			deleted, errs := cal.BatchDeleteEvents(ctx, token, hubCalID, deleteIDs)
 			result.Deleted += deleted
 			result.Errors += errs
 			for _, se := range deleteRecords {
@@ -384,11 +386,11 @@ func syncSourceToHub(ctx context.Context, token string, store *Store, config *Sy
 // syncHubToSources syncs hub placeholders outbound to each source calendar.
 // For each source calendar S, it creates/updates/deletes placeholders for
 // hub events that did NOT originate from S (no self-sync).
-func syncHubToSources(ctx context.Context, token string, store *Store, config *SyncConfig, sources []SourceCalendar, dryRun bool, result *SyncResult) error {
+func syncHubToSources(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, sources []SourceCalendar, dryRun bool, result *SyncResult) error {
 	hubCalID := config.HubCalendarID
 
 	// Fetch ALL hub placeholders as ground truth for what should exist outbound.
-	hubPlaceholders, err := ListAllPlaceholders(ctx, token, hubCalID)
+	hubPlaceholders, err := ListAllPlaceholders(ctx, cal, token, hubCalID)
 	if err != nil {
 		return fmt.Errorf("fetching hub placeholders: %w", err)
 	}
@@ -421,7 +423,7 @@ func syncHubToSources(ctx context.Context, token string, store *Store, config *S
 	// For each source calendar, propagate hub events that didn't originate from it
 	for _, source := range sources {
 		c0, u0, d0 := result.Created, result.Updated, result.Deleted
-		if err := syncOutboundToSource(ctx, token, store, config, &source, hubEvents, allSynced, dryRun, result); err != nil {
+		if err := syncOutboundToSource(ctx, cal, token, store, config, &source, hubEvents, allSynced, dryRun, result); err != nil {
 			result.addError("outbound sync error for %s: %v", source.CalendarName, err)
 		}
 		cc := result.calCounts(source.CalendarName)
@@ -433,7 +435,7 @@ func syncHubToSources(ctx context.Context, token string, store *Store, config *S
 	return nil
 }
 
-func syncOutboundToSource(ctx context.Context, token string, store *Store, config *SyncConfig, source *SourceCalendar, hubEvents []hubEvent, allSynced []SyncedEvent, dryRun bool, result *SyncResult) error {
+func syncOutboundToSource(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, source *SourceCalendar, hubEvents []hubEvent, allSynced []SyncedEvent, dryRun bool, result *SyncResult) error {
 	targetCalID := source.CalendarID
 
 	// Filter the preloaded, user-scoped synced-event set to those targeting this
@@ -446,7 +448,7 @@ func syncOutboundToSource(ctx context.Context, token string, store *Store, confi
 	}
 
 	// Fetch existing placeholders on this target calendar for adoption after DB wipe
-	existingPlaceholders, err := ListAllPlaceholders(ctx, token, targetCalID)
+	existingPlaceholders, err := ListAllPlaceholders(ctx, cal, token, targetCalID)
 	if err != nil {
 		// If we can't list (e.g. read-only), skip this calendar
 		if isPermissionError(err) {
@@ -520,7 +522,7 @@ func syncOutboundToSource(ctx context.Context, token string, store *Store, confi
 				result.Created++
 				continue
 			}
-			created, err := CreateEvent(ctx, token, targetCalID, &placeholder)
+			created, err := cal.CreateEvent(ctx, token, targetCalID, &placeholder)
 			if err != nil {
 				// Silently skip read-only calendars (UC-0047)
 				if isPermissionError(err) {
@@ -550,7 +552,7 @@ func syncOutboundToSource(ctx context.Context, token string, store *Store, confi
 				delete(syncedByKey, key)
 				continue
 			}
-			_, err := UpdateEvent(ctx, token, targetCalID, existingSe.TargetEventID, &placeholder)
+			_, err := cal.UpdateEvent(ctx, token, targetCalID, existingSe.TargetEventID, &placeholder)
 			if err != nil {
 				if isPermissionError(err) {
 					return nil
@@ -588,7 +590,7 @@ func syncOutboundToSource(ctx context.Context, token string, store *Store, confi
 		if dryRun {
 			result.Deleted += len(outboundDeleteIDs)
 		} else {
-			deleted, errs := BatchDeleteEvents(ctx, token, targetCalID, outboundDeleteIDs)
+			deleted, errs := cal.BatchDeleteEvents(ctx, token, targetCalID, outboundDeleteIDs)
 			result.Deleted += deleted
 			result.Errors += errs
 			for _, se := range outboundDeleteRecords {
@@ -612,7 +614,7 @@ func shouldSkipEventType(eventType string) bool {
 // source calendars no longer in the active config. This handles the case where
 // a user unchecks a source calendar — all its placeholders (on the hub and on
 // other source calendars) should be removed.
-func cleanupRemovedSources(ctx context.Context, token string, store *Store, activeSources []SourceCalendar, allSynced []SyncedEvent, result *SyncResult) {
+func cleanupRemovedSources(ctx context.Context, cal *calendar.Client, token string, store *Store, activeSources []SourceCalendar, allSynced []SyncedEvent, result *SyncResult) {
 	// Build set of active source calendar IDs
 	activeIDs := make(map[string]bool, len(activeSources))
 	for _, s := range activeSources {
@@ -633,7 +635,7 @@ func cleanupRemovedSources(ctx context.Context, token string, store *Store, acti
 		for _, se := range records {
 			ids = append(ids, se.TargetEventID)
 		}
-		deleted, errs := BatchDeleteEvents(ctx, token, calID, ids)
+		deleted, errs := cal.BatchDeleteEvents(ctx, token, calID, ids)
 		result.Deleted += deleted
 		result.Errors += errs
 		for _, se := range records {
@@ -644,7 +646,7 @@ func cleanupRemovedSources(ctx context.Context, token string, store *Store, acti
 
 // cleanupPastEvents deletes placeholder events whose end date is before today.
 // Placeholders only exist to prevent meeting conflicts — past events don't need them.
-func cleanupPastEvents(ctx context.Context, token string, store *Store, config *SyncConfig, sources []SourceCalendar, allSynced []SyncedEvent, result *SyncResult) {
+func cleanupPastEvents(ctx context.Context, cal *calendar.Client, token string, store *Store, config *SyncConfig, sources []SourceCalendar, allSynced []SyncedEvent, result *SyncResult) {
 	today := time.Now().UTC().Truncate(24 * time.Hour).Format("2006-01-02")
 
 	if len(allSynced) == 0 {
@@ -660,7 +662,7 @@ func cleanupPastEvents(ctx context.Context, token string, store *Store, config *
 
 	// For each target calendar, find our placeholders and check end dates
 	for calID := range targetCalIDs {
-		placeholders, err := ListAllPlaceholders(ctx, token, calID)
+		placeholders, err := ListAllPlaceholders(ctx, cal, token, calID)
 		if err != nil {
 			log.Printf("past cleanup: failed to list placeholders on %s: %v", calID, err)
 			continue
@@ -681,7 +683,7 @@ func cleanupPastEvents(ctx context.Context, token string, store *Store, config *
 			}
 
 			// Past event — delete the placeholder
-			err := DeleteEvent(ctx, token, calID, p.ID)
+			err := cal.DeleteEvent(ctx, token, calID, p.ID)
 			if err != nil && !isNotFoundError(err) {
 				result.addError("past cleanup: failed to delete %s: %v", p.ID, err)
 				continue

--- a/internal/platform/calendar/calendar.go
+++ b/internal/platform/calendar/calendar.go
@@ -1,0 +1,552 @@
+// Package calendar is a generic Google Calendar API client shared by the app's
+// modules. It knows nothing about sync placeholders or any single feature — those
+// live in the module that owns them. The API base URLs are fields on Client so tests
+// can point it at a local fake.
+package calendar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Default Google Calendar API endpoints.
+const (
+	DefaultBaseURL  = "https://www.googleapis.com/calendar/v3"
+	DefaultBatchURL = "https://www.googleapis.com/batch/calendar/v3"
+)
+
+// Client talks to the Google Calendar API. BaseURL/BatchURL are configurable so a
+// test can substitute a local fake; HTTP defaults to http.DefaultClient.
+type Client struct {
+	BaseURL  string
+	BatchURL string
+	HTTP     *http.Client
+}
+
+// New returns a Client. An empty baseURL uses the real Google endpoints.
+func New(baseURL string) *Client {
+	if baseURL == "" {
+		return &Client{BaseURL: DefaultBaseURL, BatchURL: DefaultBatchURL, HTTP: http.DefaultClient}
+	}
+	// A custom base (e.g. a test fake) also redirects batch requests to it, so the
+	// hook doesn't fake reads while batch deletes still hit real Google.
+	return &Client{BaseURL: baseURL, BatchURL: baseURL + "/batch", HTTP: http.DefaultClient}
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return http.DefaultClient
+}
+
+// --- Types ---
+
+// Calendar represents a Google Calendar from the CalendarList API.
+type Calendar struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Primary    bool   `json:"primary"`
+	AccessRole string `json:"accessRole"`
+}
+
+// GCalEvent represents a Google Calendar event with the fields we read and write.
+type GCalEvent struct {
+	ID                 string              `json:"id,omitempty"`
+	Summary            string              `json:"summary,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	Location           string              `json:"location,omitempty"`
+	Start              EventTime           `json:"start"`
+	End                EventTime           `json:"end"`
+	Status             string              `json:"status,omitempty"`
+	Transparency       string              `json:"transparency,omitempty"` // "opaque" (default/empty) or "transparent" (free)
+	ConferenceData     json.RawMessage     `json:"conferenceData,omitempty"`
+	Attachments        json.RawMessage     `json:"attachments,omitempty"`
+	Attendees          []Attendee          `json:"attendees,omitempty"`
+	Reminders          *Reminders          `json:"reminders,omitempty"`
+	ExtendedProperties *ExtendedProperties `json:"extendedProperties,omitempty"`
+	ColorID            string              `json:"colorId,omitempty"`
+	Updated            string              `json:"updated,omitempty"`
+	RecurringEventId   string              `json:"recurringEventId,omitempty"`
+	EventType          string              `json:"eventType,omitempty"` // default, workingLocation, outOfOffice, focusTime
+}
+
+// EventTime represents a Google Calendar event time (either dateTime or date for all-day).
+type EventTime struct {
+	DateTime string `json:"dateTime,omitempty"`
+	Date     string `json:"date,omitempty"`
+	TimeZone string `json:"timeZone,omitempty"`
+}
+
+// Attendee represents a Google Calendar event attendee.
+type Attendee struct {
+	Email          string `json:"email"`
+	DisplayName    string `json:"displayName,omitempty"`
+	Self           bool   `json:"self,omitempty"`
+	ResponseStatus string `json:"responseStatus,omitempty"`
+	Organizer      bool   `json:"organizer,omitempty"`
+}
+
+// Reminders controls event reminder settings.
+type Reminders struct {
+	UseDefault bool `json:"useDefault"`
+}
+
+// ExtendedProperties holds private and shared key-value pairs on an event.
+type ExtendedProperties struct {
+	Private map[string]string `json:"private,omitempty"`
+}
+
+type eventsListResponse struct {
+	Items         []GCalEvent `json:"items"`
+	NextPageToken string      `json:"nextPageToken"`
+	NextSyncToken string      `json:"nextSyncToken"`
+}
+
+type calendarListResponse struct {
+	Items []struct {
+		ID              string `json:"id"`
+		Summary         string `json:"summary"`
+		SummaryOverride string `json:"summaryOverride"`
+		Primary         bool   `json:"primary"`
+		AccessRole      string `json:"accessRole"`
+	} `json:"items"`
+	NextPageToken string `json:"nextPageToken"`
+}
+
+// ListEventsResult holds events and the sync token from a list call.
+type ListEventsResult struct {
+	Events    []GCalEvent
+	SyncToken string
+}
+
+// ErrSyncTokenExpired is returned when a sync token is no longer valid (410 Gone).
+var ErrSyncTokenExpired = fmt.Errorf("sync token expired (410 Gone)")
+
+// EventQuery filters events.list. Private-property filters combine (AND); zero
+// TimeMin/TimeMax are omitted. It subsumes the various placeholder queries.
+type EventQuery struct {
+	PrivateProps map[string]string // privateExtendedProperty key=value filters
+	TimeMin      time.Time
+	TimeMax      time.Time
+	SingleEvents bool
+}
+
+// --- Calendar list ---
+
+// ListCalendars fetches the user's calendar list.
+func (c *Client) ListCalendars(ctx context.Context, token string) ([]Calendar, error) {
+	var all []Calendar
+	pageToken := ""
+	for {
+		u := c.BaseURL + "/users/me/calendarList?maxResults=100"
+		if pageToken != "" {
+			u += "&pageToken=" + pageToken
+		}
+		body, err := c.doChecked(ctx, token, "GET", u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("listing calendars: %w", err)
+		}
+		var list calendarListResponse
+		if err := json.Unmarshal(body, &list); err != nil {
+			return nil, fmt.Errorf("decoding calendar list: %w", err)
+		}
+		for _, item := range list.Items {
+			name := item.SummaryOverride
+			if name == "" {
+				name = item.Summary
+			}
+			all = append(all, Calendar{ID: item.ID, Name: name, Primary: item.Primary, AccessRole: item.AccessRole})
+		}
+		if list.NextPageToken == "" {
+			break
+		}
+		pageToken = list.NextPageToken
+	}
+	return all, nil
+}
+
+// --- Event operations ---
+
+// ListEvents fetches events from a calendar within the given time window, plus a
+// sync token for future incremental fetches.
+func (c *Client) ListEvents(ctx context.Context, token, calendarID string, timeMin, timeMax time.Time) (*ListEventsResult, error) {
+	var result ListEventsResult
+	pageToken := ""
+	for {
+		params := url.Values{}
+		params.Set("singleEvents", "true")
+		params.Set("orderBy", "startTime")
+		params.Set("maxResults", "2500")
+		params.Set("timeMin", timeMin.Format(time.RFC3339))
+		params.Set("timeMax", timeMax.Format(time.RFC3339))
+		if pageToken != "" {
+			params.Set("pageToken", pageToken)
+		}
+		u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
+		body, err := c.doChecked(ctx, token, "GET", u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("listing events: %w", err)
+		}
+		var resp eventsListResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("decoding events: %w", err)
+		}
+		result.Events = append(result.Events, resp.Items...)
+		if resp.NextPageToken == "" {
+			result.SyncToken = resp.NextSyncToken
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return &result, nil
+}
+
+// ListEventsIncremental fetches only events changed since the given sync token.
+// Returns ErrSyncTokenExpired if the token is no longer valid.
+func (c *Client) ListEventsIncremental(ctx context.Context, token, calendarID, syncToken string) (*ListEventsResult, error) {
+	var result ListEventsResult
+	pageToken := ""
+	for {
+		params := url.Values{}
+		params.Set("syncToken", syncToken)
+		if pageToken != "" {
+			params.Set("pageToken", pageToken)
+		}
+		u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
+		body, statusCode, err := c.do(ctx, token, "GET", u, nil)
+		if statusCode == http.StatusGone {
+			return nil, ErrSyncTokenExpired
+		}
+		if err != nil {
+			return nil, err
+		}
+		if statusCode >= 400 {
+			return nil, fmt.Errorf("API status %d: %s", statusCode, string(body))
+		}
+		var resp eventsListResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("decoding incremental events: %w", err)
+		}
+		result.Events = append(result.Events, resp.Items...)
+		if resp.NextPageToken == "" {
+			result.SyncToken = resp.NextSyncToken
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return &result, nil
+}
+
+// ListEventsByProperty fetches events matching a query (private-property filters,
+// optional time window). Pages through all results.
+func (c *Client) ListEventsByProperty(ctx context.Context, token, calendarID string, q EventQuery) ([]GCalEvent, error) {
+	var all []GCalEvent
+	pageToken := ""
+	for {
+		params := url.Values{}
+		for k, v := range q.PrivateProps {
+			params.Add("privateExtendedProperty", k+"="+v)
+		}
+		if q.SingleEvents {
+			params.Set("singleEvents", "true")
+		}
+		if !q.TimeMin.IsZero() {
+			params.Set("timeMin", q.TimeMin.Format(time.RFC3339))
+		}
+		if !q.TimeMax.IsZero() {
+			params.Set("timeMax", q.TimeMax.Format(time.RFC3339))
+		}
+		params.Set("maxResults", "2500")
+		if pageToken != "" {
+			params.Set("pageToken", pageToken)
+		}
+		u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) + "/events?" + params.Encode()
+		body, err := c.doChecked(ctx, token, "GET", u, nil)
+		if err != nil {
+			return nil, fmt.Errorf("listing events by property: %w", err)
+		}
+		var resp eventsListResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("decoding events: %w", err)
+		}
+		all = append(all, resp.Items...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
+}
+
+// CreateEvent creates an event on the specified calendar.
+func (c *Client) CreateEvent(ctx context.Context, token, calendarID string, event *GCalEvent) (*GCalEvent, error) {
+	u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) +
+		"/events?conferenceDataVersion=1&supportsAttachments=true&sendUpdates=none"
+	jsonBody, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.doChecked(ctx, token, "POST", u, jsonBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating event: %w", err)
+	}
+	var created GCalEvent
+	if err := json.Unmarshal(body, &created); err != nil {
+		return nil, fmt.Errorf("decoding created event: %w", err)
+	}
+	return &created, nil
+}
+
+// UpdateEvent patches an event on the specified calendar.
+func (c *Client) UpdateEvent(ctx context.Context, token, calendarID, eventID string, event *GCalEvent) (*GCalEvent, error) {
+	u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) +
+		"/events/" + url.PathEscape(eventID) +
+		"?conferenceDataVersion=1&supportsAttachments=true&sendUpdates=none"
+	jsonBody, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.doChecked(ctx, token, "PATCH", u, jsonBody)
+	if err != nil {
+		return nil, fmt.Errorf("updating event: %w", err)
+	}
+	var updated GCalEvent
+	if err := json.Unmarshal(body, &updated); err != nil {
+		return nil, fmt.Errorf("decoding updated event: %w", err)
+	}
+	return &updated, nil
+}
+
+// DeleteEvent deletes an event from the specified calendar. An already-deleted
+// event (404/410) is treated as success — deletion is idempotent.
+func (c *Client) DeleteEvent(ctx context.Context, token, calendarID, eventID string) error {
+	u := c.BaseURL + "/calendars/" + url.PathEscape(calendarID) +
+		"/events/" + url.PathEscape(eventID) + "?sendUpdates=none"
+	body, status, err := c.do(ctx, token, "DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusNoContent || status == http.StatusOK ||
+		status == http.StatusGone || status == http.StatusNotFound {
+		return nil
+	}
+	if status >= 400 {
+		return fmt.Errorf("API status %d: %s", status, string(body))
+	}
+	return nil
+}
+
+// BatchDeleteEvents deletes multiple events using Google's batch API (≤50 per
+// request). Returns counts of deleted and errored.
+func (c *Client) BatchDeleteEvents(ctx context.Context, token, calendarID string, eventIDs []string) (deleted, errors int) {
+	const batchSize = 50
+	for i := 0; i < len(eventIDs); i += batchSize {
+		end := i + batchSize
+		if end > len(eventIDs) {
+			end = len(eventIDs)
+		}
+		d, e := c.doBatchDelete(ctx, token, calendarID, eventIDs[i:end])
+		deleted += d
+		errors += e
+	}
+	return
+}
+
+func (c *Client) doBatchDelete(ctx context.Context, token, calendarID string, eventIDs []string) (deleted, errors int) {
+	// Boundary must be an RFC 2046 token (no tspecials like '@', ≤70 chars), so it
+	// is derived from a timestamp, never from the calendar ID.
+	boundary := "batch_calsync_" + fmt.Sprintf("%d", time.Now().UnixNano())
+	var body bytes.Buffer
+	for i, eventID := range eventIDs {
+		body.WriteString("--" + boundary + "\r\n")
+		body.WriteString("Content-Type: application/http\r\n")
+		body.WriteString(fmt.Sprintf("Content-ID: <item%d>\r\n", i))
+		body.WriteString("\r\n")
+		path := "/calendar/v3/calendars/" + url.PathEscape(calendarID) +
+			"/events/" + url.PathEscape(eventID) + "?sendUpdates=none"
+		body.WriteString("DELETE " + path + " HTTP/1.1\r\n")
+		body.WriteString("\r\n")
+	}
+	body.WriteString("--" + boundary + "--\r\n")
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.BatchURL, &body)
+	if err != nil {
+		return 0, len(eventIDs)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "multipart/mixed; boundary="+boundary)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return 0, len(eventIDs)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, len(eventIDs)
+	}
+	// Count per-part HTTP status lines in the multipart response.
+	for _, line := range strings.Split(string(respBody), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "HTTP/1.1 2") {
+			deleted++
+		} else if strings.HasPrefix(line, "HTTP/1.1 4") || strings.HasPrefix(line, "HTTP/1.1 5") {
+			errors++
+		}
+	}
+	return
+}
+
+// --- HTTP with classified retry ---
+
+// doChecked makes a request and returns an error for any status >= 400.
+func (c *Client) doChecked(ctx context.Context, token, method, u string, body []byte) ([]byte, error) {
+	respBody, status, err := c.do(ctx, token, method, u, body)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, fmt.Errorf("API status %d: %s", status, string(respBody))
+	}
+	return respBody, nil
+}
+
+// do makes a request with backoff on retryable errors, returning body and status.
+// Retries only transient failures (429, 5xx, and rate/quota-reason 403s); other
+// 4xx fail fast so a permanent 403 (e.g. read-only calendar) doesn't hang.
+func (c *Client) do(ctx context.Context, token, method, rawURL string, reqBody []byte) ([]byte, int, error) {
+	const maxRetries = 5
+	baseDelay := 500 * time.Millisecond
+	maxDelay := 30 * time.Second
+
+	for attempt := range maxRetries {
+		var bodyReader io.Reader
+		if reqBody != nil {
+			bodyReader = bytes.NewReader(reqBody)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, rawURL, bodyReader)
+		if err != nil {
+			return nil, 0, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		if reqBody != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient().Do(req)
+		if err != nil {
+			return nil, 0, fmt.Errorf("request failed: %w", err)
+		}
+		respBody, err := io.ReadAll(resp.Body)
+		retryAfter := resp.Header.Get("Retry-After")
+		resp.Body.Close()
+		if err != nil {
+			return nil, 0, fmt.Errorf("reading response: %w", err)
+		}
+
+		if attempt < maxRetries-1 && isRetryable(resp.StatusCode, errorReason(respBody)) {
+			delay := baseDelay * time.Duration(1<<attempt)
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			// Jitter ±25%.
+			delay = time.Duration(float64(delay) * (0.75 + rand.Float64()*0.5))
+			if ra := parseRetryAfter(retryAfter); ra > 0 {
+				delay = min(ra, maxDelay) // honor server hint, but never sleep unbounded
+			}
+			select {
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			case <-time.After(delay):
+			}
+			continue
+		}
+		return respBody, resp.StatusCode, nil
+	}
+	return nil, 0, fmt.Errorf("max retries exceeded")
+}
+
+// isRetryable reports whether a failed response is a transient error worth retrying.
+func isRetryable(status int, reason string) bool {
+	if status == http.StatusTooManyRequests || status >= 500 {
+		return true
+	}
+	if status == http.StatusForbidden {
+		switch reason {
+		case "rateLimitExceeded", "userRateLimitExceeded", "quotaExceeded", "backendError", "RESOURCE_EXHAUSTED":
+			return true
+		}
+	}
+	return false
+}
+
+// errorReason extracts the first Google API error reason from a response body.
+func errorReason(body []byte) string {
+	var e struct {
+		Error struct {
+			Status string `json:"status"`
+			Errors []struct {
+				Reason string `json:"reason"`
+			} `json:"errors"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &e) != nil {
+		return ""
+	}
+	if len(e.Error.Errors) > 0 {
+		return e.Error.Errors[0].Reason
+	}
+	return e.Error.Status
+}
+
+// parseRetryAfter parses a Retry-After header given in delta-seconds. Returns 0 if
+// absent or in HTTP-date form (we fall back to computed backoff there).
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return 0
+}
+
+// --- Stateless helpers ---
+
+// IsDeclined returns true if the authenticated user has declined this event.
+func IsDeclined(event GCalEvent) bool {
+	for _, a := range event.Attendees {
+		if a.Self && a.ResponseStatus == "declined" {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatAttendees formats an attendee list as a human-readable string.
+func FormatAttendees(attendees []Attendee) string {
+	var parts []string
+	for _, a := range attendees {
+		name := a.DisplayName
+		if name == "" {
+			name = a.Email
+		} else {
+			name += " <" + a.Email + ">"
+		}
+		if a.Organizer {
+			name += " (organizer)"
+		}
+		parts = append(parts, name)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/platform/calendar/calendar_test.go
+++ b/internal/platform/calendar/calendar_test.go
@@ -1,0 +1,143 @@
+package calendar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestIsRetryable(t *testing.T) {
+	cases := []struct {
+		status int
+		reason string
+		want   bool
+	}{
+		{429, "", true},
+		{500, "", true},
+		{503, "backendError", true},
+		{403, "rateLimitExceeded", true},
+		{403, "userRateLimitExceeded", true},
+		{403, "quotaExceeded", true},
+		{403, "RESOURCE_EXHAUSTED", true}, // status fallback when errors[] absent
+		{403, "forbidden", false},        // permanent — must fail fast
+		{403, "", false},                 // no reason — treat as permanent
+		{404, "", false},
+		{400, "badRequest", false},
+		{200, "", false},
+	}
+	for _, c := range cases {
+		if got := isRetryable(c.status, c.reason); got != c.want {
+			t.Errorf("isRetryable(%d, %q) = %v, want %v", c.status, c.reason, got, c.want)
+		}
+	}
+}
+
+func TestErrorReason(t *testing.T) {
+	body := []byte(`{"error":{"code":403,"status":"PERMISSION_DENIED","errors":[{"reason":"rateLimitExceeded","message":"slow down"}]}}`)
+	if got := errorReason(body); got != "rateLimitExceeded" {
+		t.Errorf("errorReason = %q, want rateLimitExceeded", got)
+	}
+	if got := errorReason([]byte(`not json`)); got != "" {
+		t.Errorf("errorReason(non-json) = %q, want empty", got)
+	}
+}
+
+// A permanent 403 must fail fast — one request, no retries — so a bulk operation
+// against a read-only calendar can't hang.
+func TestPermanent403FailsFast(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":{"code":403,"errors":[{"reason":"forbidden"}]}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	_, err := c.ListCalendars(context.Background(), "tok")
+	if err == nil {
+		t.Fatal("expected error on permanent 403")
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("expected 1 request (no retries), got %d", n)
+	}
+}
+
+// A rate-limit 403 is retried and can then succeed.
+func TestRateLimit403Retries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":{"code":403,"errors":[{"reason":"rateLimitExceeded"}]}}`))
+			return
+		}
+		w.Write([]byte(`{"items":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	if _, err := c.ListCalendars(context.Background(), "tok"); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("expected 2 requests (one retry), got %d", n)
+	}
+}
+
+// The multipart boundary must stay a valid MIME token even when the calendar ID
+// is email-shaped (contains '@', an RFC 2045 tspecial).
+func TestBatchDeleteBoundaryIsValid(t *testing.T) {
+	var boundary string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); strings.Contains(ct, "boundary=") {
+			boundary = ct[strings.Index(ct, "boundary=")+len("boundary="):]
+		}
+		w.Header().Set("Content-Type", "multipart/mixed; boundary=resp")
+		w.Write([]byte("--resp\r\n\r\nHTTP/1.1 204 No Content\r\n\r\n--resp\r\n\r\nHTTP/1.1 204 No Content\r\n\r\n--resp--\r\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL) // BatchURL = srv.URL + "/batch"
+	deleted, errs := c.BatchDeleteEvents(context.Background(), "tok", "michaelw@xwind.io", []string{"a", "b"})
+	if deleted != 2 || errs != 0 {
+		t.Fatalf("deleted=%d errs=%d, want 2/0", deleted, errs)
+	}
+	if boundary == "" || len(boundary) > 70 || strings.ContainsAny(boundary, "@()<>,;:\\\"/[]?= \t") {
+		t.Fatalf("invalid MIME boundary: %q", boundary)
+	}
+}
+
+// Deleting an already-gone event (404/410) is success; a real error is not.
+func TestDeleteEventIdempotent(t *testing.T) {
+	cases := []struct {
+		status  int
+		wantErr bool
+	}{
+		{http.StatusNoContent, false},
+		{http.StatusOK, false},
+		{http.StatusGone, false},
+		{http.StatusNotFound, false},
+		{http.StatusForbidden, true},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			if tc.status >= 400 {
+				w.Write([]byte(`{"error":{"errors":[{"reason":"forbidden"}]}}`))
+			}
+		}))
+		c := New(srv.URL)
+		err := c.DeleteEvent(context.Background(), "tok", "cal", "evt")
+		srv.Close()
+		if tc.wantErr && err == nil {
+			t.Errorf("status %d: expected error", tc.status)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("status %d: expected success, got %v", tc.status, err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,7 @@ import (
 	appcli "github.com/michaelwinser/appbase/cli"
 
 	"github.com/michaelwinser/calendar-sync/internal/app"
+	"github.com/michaelwinser/calendar-sync/internal/platform/calendar"
 )
 
 var (
@@ -51,7 +53,9 @@ func setup() error {
 		return err
 	}
 
-	appSrv = &app.Server{Store: store, Google: a.Google()}
+	// CALENDAR_API_BASE lets tests point the client at a local fake; empty = real Google.
+	cal := calendar.New(os.Getenv("CALENDAR_API_BASE"))
+	appSrv = &app.Server{Store: store, Google: a.Google(), Cal: cal}
 	appSrv.RegisterRoutes(a.Router())
 
 	// Nudge endpoint — registered outside /api/ to bypass session auth middleware.


### PR DESCRIPTION
First implementation step of M6 (see docs/M6-plan.md §6.2). Carves the generic Google Calendar API surface out of `internal/app/gcal.go` into a new `internal/platform/calendar` package, so the sync/tools/heatmap modules can share one calendar layer.

## What changed
- **`internal/platform/calendar`** (new): a configurable `Client{BaseURL, BatchURL, HTTP}`.
  - `BaseURL` injectable via `CALENDAR_API_BASE` (empty = real Google) so tests/e2e can point at a fake; a custom base also redirects batch.
  - `Client.Do` centralizes **classified retry**: retry only transient failures (429, 5xx, rate/quota-reason 403s), honor `Retry-After` (capped at maxDelay); **fail fast on other 4xx** so a permanent 403 (read-only calendar) no longer burns 5× backoff.
  - `ListEventsByProperty(opts)` subsumes the placeholder queries (private-property filters + time window). Dead `ListPlaceholdersInRange` removed.
  - `DeleteEvent` idempotent (404/410 = success).
- **`internal/app/gcal.go`**: reduced to sync-specific logic (placeholder marker, `BuildPlaceholder`, query wrappers) + type aliases so existing code/tests are unchanged.
- **sync / server / main**: thread the `*calendar.Client` through (`Server.Cal`, sync entry points).

## Behavior
Behavior-preserving **except** the retry classification. Incidental real fix: `ListEventsIncremental` now checks status before unmarshalling — a 401/403 is a real error instead of a silent zero-event no-op sync.

## Tests
New `calendar` unit tests: retry classification, idempotent delete, and the batch **MIME boundary** (regression — must stay a valid token for email-shaped calendar IDs; the pre-fix version silently failed every batch delete on the primary calendar). `./dev ci` green.

## Review
Ran the pre-commit code-review agent; three MUST-FIX items found and fixed (malformed batch boundary, `CALENDAR_API_BASE` not redirecting batch, unbounded `Retry-After`).

Sync data model and `v1.1.0` production behavior untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)